### PR TITLE
Add options to manually open the achievement table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ But wait - there's more! It can also let you know about world quests that award 
 
 Additionally it tracks emissaries and mission tables from Warlords of Draenor, Legion and Battle for Azeroth.
 
-You'll get notifications either in your chat or as a separate window.
+You'll get notifications either in your chat or as a separate window. You can also click on the mini map icon or write the following command to show the table with the world quests:
+```
+/wqa
+```
 
 ![chat](https://user-images.githubusercontent.com/13890391/54945075-4b7f3680-4f35-11e9-9e5d-b7c73290b0b0.png)
 


### PR DESCRIPTION
Hi @Urtgard ! I downloaded your addon, I like it! 

I created this PR because I had to spend some time looking at how to show the achievements table again after I had closed the initial one, I found out you can show it by clicking the icon map or by the /wqa slash command. I thought maybe we can make this easier for future users by updating the readme. Let me know what you think!