### PR TITLE
Change Popup's scale and z-level to match enclosed tooltip's

### DIFF
--- a/WQAchievements.lua
+++ b/WQAchievements.lua
@@ -2763,6 +2763,8 @@ function WQA:AnnouncePopUp(quests, silent)
 	self:UpdateQTip(quests)
 	PopUp:SetWidth(self.tooltip:GetWidth() + 8.5)
 	PopUp:SetHeight(self.tooltip:GetHeight() + 32)
+	PopUp:SetScale(self.tooltip:GetScale())
+	PopUp:SetFrameLevel(self.tooltip:GetFrameLevel())
 
 	if self.db.profile.options.popupRememberPosition then
 		PopUp:ClearAllPoints()


### PR DESCRIPTION
Other addons sometimes massage tooltips whenever they're displayed (TipTac is the one I use), leading to weird sizing and overlap situations like this:
![before](https://user-images.githubusercontent.com/307232/97791844-1cb75080-1bad-11eb-9cc3-07e1af60fd7c.png)

This change ties the z-axis layer and scale of the Popup frame to that of  the tooltip:
![after](https://user-images.githubusercontent.com/307232/97791852-3a84b580-1bad-11eb-8916-e8b7c1e29ee5.png)
