### PR TITLE
Make expansion names look more header-ish, and indent quests

### DIFF
--- a/WQAchievements.lua
+++ b/WQAchievements.lua
@@ -2591,7 +2591,8 @@ function WQA:UpdateQTip(tasks)
 					j = 2
 					if GetExpansion(task) ~= expansion then
 						expansion = GetExpansion(task)
-						tooltip:AddLine(GetExpansionName(expansion))
+						local row = tooltip:AddLine(GetExpansionName(expansion))
+						tooltip:SetLineTextColor(row, 0, 1, 0)
 						i = i + 1
 						zoneID = nil
 					end
@@ -2604,7 +2605,7 @@ function WQA:UpdateQTip(tasks)
 					j = 2
 					if GetTaskZoneID(task) ~= zoneID then
 						zoneID = GetTaskZoneID(task)
-						tooltip:SetCell(i, 1, GetTaskZoneName(task))
+						tooltip:SetCell(i, 1, "     " .. GetTaskZoneName(task))
 					end
 				end
 

--- a/WQAchievements.lua
+++ b/WQAchievements.lua
@@ -2591,8 +2591,7 @@ function WQA:UpdateQTip(tasks)
 					j = 2
 					if GetExpansion(task) ~= expansion then
 						expansion = GetExpansion(task)
-						local row = tooltip:AddLine(GetExpansionName(expansion))
-						tooltip:SetLineTextColor(row, 0, 1, 0)
+						tooltip:AddLine(string.format("|cff33ff33%s|r", GetExpansionName(expansion)))
 						i = i + 1
 						zoneID = nil
 					end


### PR DESCRIPTION
This is a quick hack to make the window "table" look a little more tabular, coloring expansion names, and indenting zone names.  It's totally cosmetic but makes busy tables look better I think.
![WQA](https://user-images.githubusercontent.com/307232/165191772-5733d223-1340-44ad-aee6-a051bfcc2c8b.jpg)
.