### PR TITLE
11.0.5 QuestID Rename

### DIFF
--- a/Achievements.lua
+++ b/Achievements.lua
@@ -132,13 +132,13 @@ function WQA.Achievements:Register_MISSION_TABLE(achievement, index, criteriaQue
 
     if achievement.criteria and achievement.criteria[index] then
         if type(achievement.criteria[index]) == "table" then
-            for _, questId in pairs(achievement.criteria[index]) do
-                WQA:AddRewardToMission(questId, "ACHIEVEMENT", id)
+            for _, questID in pairs(achievement.criteria[index]) do
+                WQA:AddRewardToMission(questID, "ACHIEVEMENT", id)
             end
         else
-            local questId = achievement.criteria[index]
-            if questId then
-                WQA:AddRewardToMission(questId, "ACHIEVEMENT", id)
+            local questID = achievement.criteria[index]
+            if questID then
+                WQA:AddRewardToMission(questID, "ACHIEVEMENT", id)
             end
         end
     else

--- a/Options.lua
+++ b/Options.lua
@@ -526,8 +526,8 @@ function WQA:UpdateOptions()
 								end,
 								disabled = function()
 									local mapId = self.data.custom.mapID
-									local questId = self.data.custom.wqID
-									return (questId == nil or questId == "") or
+									local questID = self.data.custom.wqID
+									return (questID == nil or questID == "") or
 										(self.data.custom.questType == "QUEST_PIN" and (mapId == nil or mapId == ""))
 								end
 							},

--- a/WQAchievements.lua
+++ b/WQAchievements.lua
@@ -184,7 +184,7 @@ function WQA:OnEnable()
 						for i = 1, #self.ZoneIDList do
 							for _, mapID in pairs(self.ZoneIDList[i]) do
 								if self.db.profile.options.zone[mapID] == true then
-									local quests = C_TaskQuest.GetQuestsForPlayerByMapID(mapID)
+									local quests = C_TaskQuest.GetQuestsOnMap(mapID)
 									if quests then
 										for j = 1, #quests do
 											local questID = quests[j].questID
@@ -929,7 +929,7 @@ function WQA:Reward()
 	for i in pairs(self.ZoneIDList) do
 		for _, mapID in pairs(self.ZoneIDList[i]) do
 			if self.db.profile.options.zone[mapID] == true then
-				local quests = C_TaskQuest.GetQuestsForPlayerByMapID(mapID)
+				local quests = C_TaskQuest.GetQuestsOnMap(mapID)
 				if quests then
 					for i = 1, #quests do
 						local questID = quests[i].questID

--- a/WQAchievements.lua
+++ b/WQAchievements.lua
@@ -187,7 +187,7 @@ function WQA:OnEnable()
 									local quests = C_TaskQuest.GetQuestsForPlayerByMapID(mapID)
 									if quests then
 										for j = 1, #quests do
-											local questID = quests[j].questId
+											local questID = quests[j].questID
 											local numQuestRewards = GetNumQuestLogRewards(questID)
 											if numQuestRewards > 0 then
 												GetQuestLogRewardInfo(1, questID)
@@ -932,7 +932,7 @@ function WQA:Reward()
 				local quests = C_TaskQuest.GetQuestsForPlayerByMapID(mapID)
 				if quests then
 					for i = 1, #quests do
-						local questID = quests[i].questId
+						local questID = quests[i].questID
 						local questTagInfo = GetQuestTagInfo(questID)
 						local worldQuestType = 0
 						if questTagInfo then
@@ -1570,7 +1570,7 @@ function WQA:GetRewardLinkByMissionID(missionID, key, value, i)
 	return self:GetRewardLinkByID(missionID, key, value, i)
 end
 
-function WQA:GetRewardLinkByID(questId, key, value, i)
+function WQA:GetRewardLinkByID(questID, key, value, i)
 	local k, v = key, value
 	local link = nil
 	if k == "achievement" then


### PR DESCRIPTION
So far only fix needed is QuestID rename from questId to questID in the WQAchievements.lua, there may be more changes needed but initial push for issue https://github.com/Urtgard/WQAchievements/issues/168