### PR TITLE
Add “Medallion of Service” (Kyrian covenant) currency

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -29,6 +29,7 @@ local CurrencyIDList = {
 		1166                           -- Timewarped Badge
 	},
 	[9] = {
+		1819, -- Medallion of Service (Kyrian covenant)
 		1889 -- Adventure Campaign Progress
 	},
 	[10] = {


### PR DESCRIPTION
This adds the [Medallion of Service](https://www.wowhead.com/currency=1819/medallion-of-service) currency for the SL mission table:

<img width="650" alt="Screenshot 2024-11-15 at 14 27 15-2" src="https://github.com/user-attachments/assets/d1ef65e2-836e-4d76-b3dc-a2803816fd16">

<img width="540" alt="medofserv" src="https://github.com/user-attachments/assets/6078ef73-8017-4046-b479-a7217e18abe2">


This currency is still useful to acquire [Supplies for the Path](https://www.wowhead.com/item=184444/supplies-for-the-path), which in turn contains mats for crafting the Kyrian-Cov-only [Skystrider Glider](https://www.wowhead.com/item=180445/skystrider-glider), a very profitable and good seller on the Auction House (item is needed to capture the [Sundancer](https://www.wowhead.com/npc=170548/sundancer) rare mount in Bastion).

Until now I did not need this reminder in WQA, as my only Kyrian alt was always stationed at the SL mission table, but now with all the alts living in 20th-Anniversary Tanaris, a reminder would be handy 😀