### PR TITLE
Fix right-click on LDB button to open the settings panel

### DIFF
--- a/WQAchievements.lua
+++ b/WQAchievements.lua
@@ -165,7 +165,7 @@ function WQA:OnEnable()
 			return self:GetOptions()
 		end
 	)
-	self.optionsFrame = LibStub("AceConfigDialog-3.0"):AddToBlizOptions("WQAchievements", "WQAchievements")
+	self.optionsFrame, self.optionsID = LibStub("AceConfigDialog-3.0"):AddToBlizOptions("WQAchievements", "WQAchievements")
 	local profiles = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db)
 	LibStub("AceConfig-3.0"):RegisterOptionsTable("WQAProfiles", profiles)
 	self.optionsFrame.Profiles =
@@ -1782,7 +1782,7 @@ function dataobj:OnClick(button)
 	if button == "LeftButton" then
 		WQA:Show("popup")
 	elseif button == "RightButton" then
-		Settings.OpenToCategory("WQAchievements")
+		Settings.OpenToCategory(WQA.optionsID)
 	end
 end
 


### PR DESCRIPTION
Right-clicking the LDB button gives me this error, instead of opening the WQA settings panel:

```denizenscript
4x ...ddOns/Blizzard_Settings_Shared/Blizzard_Settings.lua:144: bad argument #1 to 'OpenSettingsPanel' (outside of expected range -2147483648 to 2147483647 - Usage: C_SettingsUtil.OpenSettingsPanel([openToCategoryID, scrollToElementName]))
[Blizzard_Settings_Shared/Blizzard_Settings.lua]:144: in function 'OpenToCategory'
[WQAchievements/WQAchievements.lua]:1785: in function 'OnClick'
[Bazooka/Bazooka.lua]:1414: in function <Bazooka/Bazooka.lua:1411>


Locals:
categoryID="WQAchievements"
scrollToElementName=nil
```

---

It seems `Settings.OpenToCategory` expects the category ID, not a frame name string.

The PR fixes this.
